### PR TITLE
Fix compatibility with maven-shade-plugin 3.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-shade-plugin</artifactId>
-            <version>3.2.1</version>
+            <version>3.2.3</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/com/github/edwgiz/maven_shade_plugin/log4j2_cache_transformer/PluginsCacheFileTransformer.java
+++ b/src/main/java/com/github/edwgiz/maven_shade_plugin/log4j2_cache_transformer/PluginsCacheFileTransformer.java
@@ -66,7 +66,8 @@ public class PluginsCacheFileTransformer implements ResourceTransformer {
     @Override
     public void processResource(final String resource,
             final InputStream resourceInput,
-            final List<Relocator> relocators) throws IOException {
+            final List<Relocator> relocators,
+            final long time) throws IOException {
         final Path tempFile = Files.createTempFile("Log4j2Plugins", "dat");
         Files.copy(resourceInput, tempFile, REPLACE_EXISTING);
         tempFiles.add(tempFile);

--- a/src/test/java/com/github/edwgiz/maven_shade_plugin/log4j2_cache_transformer/PluginsCacheFileTransformerTest.java
+++ b/src/test/java/com/github/edwgiz/maven_shade_plugin/log4j2_cache_transformer/PluginsCacheFileTransformerTest.java
@@ -37,12 +37,12 @@ final class PluginsCacheFileTransformerTest {
         final PluginsCacheFileTransformer transformer = new PluginsCacheFileTransformer();
         try (InputStream log4jCacheFileInputStream = getClass().getClassLoader()
                 .getResourceAsStream(PLUGIN_CACHE_FILE)) {
-            transformer.processResource(PLUGIN_CACHE_FILE, log4jCacheFileInputStream, null);
+            transformer.processResource(PLUGIN_CACHE_FILE, log4jCacheFileInputStream, null, 0L);
             assertFalse(transformer.hasTransformedResource());
 
             final List<Relocator> relocators = new ArrayList<>();
             relocators.add(new SimpleRelocator(null, null, null, null));
-            transformer.processResource(PLUGIN_CACHE_FILE, log4jCacheFileInputStream, relocators);
+            transformer.processResource(PLUGIN_CACHE_FILE, log4jCacheFileInputStream, relocators, 0L);
         }
         assertTrue(transformer.hasTransformedResource());
     }


### PR DESCRIPTION
This transformer is not compatible with maven-shade-plugin's latest version (3.2.3) because an abstract class' constructor has changed. This PR fixes that.

`log4j2-cachefile-transformer`'s version should be updated but I don't know what should be the right version number, as it normally matches log4j. I hope the maintainer can take care of that aspect (@edwgiz)