### PR TITLE
Upgrade to log4j 2.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.edwgiz</groupId>
     <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
-    <version>2.13.0</version>
+    <version>2.13.1</version>
 
     <name>Maven Shade Log4j2 transformer</name>
     <description>Transformer implementation to concatenate Log4j2Plugins.dat files</description>
@@ -43,13 +43,13 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.13.0</version>
+            <version>2.13.1</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.13.0</version>
+            <version>2.13.1</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
This could be a good opportunity to release `maven-shade-plugin.log4j2-cachefile-transformer 2.13.1` and at the same time include [this fix](https://github.com/edwgiz/maven-shaded-log4j-transformer/pull/2).